### PR TITLE
Added support for `Bytes` type.

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model Token {
   /// @prismabox.hide
   tokenHash String
   expiresAt DateTime
+  tokenBuffer Bytes
 
   pendingEmailConfirmations  Email[]
   pendingCredentialCreations PendingCredentialCreateTask[]

--- a/src/generators/primitiveField.ts
+++ b/src/generators/primitiveField.ts
@@ -10,6 +10,7 @@ const PrimitiveFields = [
 	"Date",
 	"Json",
 	"Boolean",
+	"Bytes",
 ] as const;
 
 export type PrimitivePrismaFieldType = (typeof PrimitiveFields)[number];
@@ -50,6 +51,10 @@ export function stringifyPrimitiveType({
 
 	if (fieldType === "Boolean") {
 		return `${getConfig().typeboxImportVariableName}.Boolean(${options})`;
+	}
+
+	if (fieldType === "Bytes") {
+		return `${getConfig().typeboxImportVariableName}.Uint8Array(${options})`;
 	}
 
 	throw new Error("Invalid type for primitive generation");


### PR DESCRIPTION
This adds support for the [`Bytes`](https://www.prisma.io/docs/orm/reference/prisma-schema-reference#bytes) scalar type. Since Typebox only supports `Uint8Array` I didn't bother adding additional support for the other `Uint*Array` types that exist in JavaScript.

I added a field to the `Token` model to test this change.