### PR TITLE
Add option to only generate json types

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ const configSchema = Type.Object(
 		ignoreUpdatedAtOnInputModel: Type.Boolean({ default: true }),
 		nullableName: Type.String({ default: "__nullable__" }),
 		allowRecursion: Type.Boolean({ default: true }),
+    useJsonTypes: Type.Boolean({ default: false })
 	},
 	{ additionalProperties: false },
 );

--- a/src/generators/primitiveField.ts
+++ b/src/generators/primitiveField.ts
@@ -1,61 +1,75 @@
 import { getConfig } from "../config";
 
 const PrimitiveFields = [
-	"Int",
-	"BigInt",
-	"Float",
-	"Decimal",
-	"String",
-	"DateTime",
-	"Date",
-	"Json",
-	"Boolean",
-	"Bytes",
+  "Int",
+  "BigInt",
+  "Float",
+  "Decimal",
+  "String",
+  "DateTime",
+  "Date",
+  "Json",
+  "Boolean",
+  "Bytes",
 ] as const;
 
 export type PrimitivePrismaFieldType = (typeof PrimitiveFields)[number];
 
 export function isPrimitivePrismaFieldType(
-	str: string,
+  str: string,
 ): str is PrimitivePrismaFieldType {
-	// biome-ignore lint/suspicious/noExplicitAny: we want to check if the string is a valid primitive field
-	return PrimitiveFields.includes(str as any);
+  // biome-ignore lint/suspicious/noExplicitAny: we want to check if the string is a valid primitive field
+  return PrimitiveFields.includes(str as any);
 }
 
 export function stringifyPrimitiveType({
-	fieldType,
-	options,
+  fieldType,
+  options,
 }: {
-	fieldType: PrimitivePrismaFieldType;
-	options: string;
+  fieldType: PrimitivePrismaFieldType;
+  options: string;
 }) {
-	if (["Int", "BigInt"].includes(fieldType)) {
-		return `${getConfig().typeboxImportVariableName}.Integer(${options})`;
-	}
+  if (["Int", "BigInt"].includes(fieldType)) {
+    return `${getConfig().typeboxImportVariableName}.Integer(${options})`;
+  }
 
-	if (["Float", "Decimal"].includes(fieldType)) {
-		return `${getConfig().typeboxImportVariableName}.Number(${options})`;
-	}
+  if (["Float", "Decimal"].includes(fieldType)) {
+    return `${getConfig().typeboxImportVariableName}.Number(${options})`;
+  }
 
-	if (fieldType === "String") {
-		return `${getConfig().typeboxImportVariableName}.String(${options})`;
-	}
+  if (fieldType === "String") {
+    return `${getConfig().typeboxImportVariableName}.String(${options})`;
+  }
 
-	if (["DateTime", "Date"].includes(fieldType)) {
-		return `${getConfig().typeboxImportVariableName}.Date(${options})`;
-	}
+  if (["DateTime", "Date"].includes(fieldType)) {
+    const config = getConfig()
 
-	if (fieldType === "Json") {
-		return `${getConfig().typeboxImportVariableName}.Any(${options})`;
-	}
+    if (config.useJsonTypes) {
+      let opts = JSON.parse(options);
 
-	if (fieldType === "Boolean") {
-		return `${getConfig().typeboxImportVariableName}.Boolean(${options})`;
-	}
+      if (fieldType == "DateTime") {
+        opts.format = 'date-time'
+      } else {
+        opts.format = 'date'
+      }
 
-	if (fieldType === "Bytes") {
-		return `${getConfig().typeboxImportVariableName}.Uint8Array(${options})`;
-	}
+      return `${config.typeboxImportVariableName}.String(${JSON.stringify(opts)})`;
+    }
 
-	throw new Error("Invalid type for primitive generation");
+    return `${config.typeboxImportVariableName}.Date(${options})`;
+  }
+
+  if (fieldType === "Json") {
+    return `${getConfig().typeboxImportVariableName}.Any(${options})`;
+  }
+
+  if (fieldType === "Boolean") {
+    return `${getConfig().typeboxImportVariableName}.Boolean(${options})`;
+  }
+
+  if (fieldType === "Bytes") {
+    return `${getConfig().typeboxImportVariableName}.Uint8Array(${options})`;
+  }
+
+  throw new Error("Invalid type for primitive generation");
 }


### PR DESCRIPTION
Hi!

The[ fastify-type-provider-typebox](https://github.com/sinclairzx81/typebox/issues/822#issuecomment-2048909574) only supports JSON types, which means we can't use the `Type.Date` type with Fastify.

This PR introduces a `useJsonTypes` config option. When enabled, this option ensures that only primitive types are generated as JSON types.

I attempted to test these changes locally but couldn't figure out how to correctly link the local prismabox package to my project. 

```bash
❯ npm i -D prismabox

added 3 packages, changed 1 package, and audited 273 packages in 1s

39 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

❯ npm link /Users/brancobruyneel/dev/prismabox

removed 3 packages, changed 1 package, and audited 271 packages in 687ms

38 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
Reshimming asdf nodejs...

❯ npx prisma generate
Prisma schema loaded from prisma/schema.prisma
Error: Generator "prismabox" failed:

/bin/sh: prismabox: command not found
```