### PR TITLE
fix: escape backticks in doc comments

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,12 +8,12 @@ generator client {
 }
 
 generator prismabox {
-  provider   = "node ./dist/cli.js"
-  inputModel = true
-  output     = "./generated/schema"
+  provider              = "node ./dist/cli.js"
+  inputModel            = true
+  output                = "./generated/schema"
   additionalFieldsPlain = ["additional: Type.Optional(Type.String())"]
-  useJsonTypes = true
-  allowRecursion = false
+  useJsonTypes          = true
+  allowRecursion        = false
 }
 
 model Password {
@@ -69,7 +69,7 @@ model Email {
   @@unique([userId, email])
 }
 
-/// A user in the system
+/// A `user` in the system
 model User {
   id                             String                        @id @default(uuid())
   createdAt                      DateTime                      @default(now())
@@ -319,11 +319,11 @@ model Message {
 }
 
 model User2 {
-  id             String          @id @default(uuid())
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
+  id             String   @id @default(uuid())
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
   /// @prismabox.input.hide
-  authProviderId String          @unique
+  authProviderId String   @unique
   /// @prismabox.input.hide
   domainId       String
   firstName      String
@@ -333,7 +333,7 @@ model User2 {
   sponsor        String
   company        String
   /// custom user attributes from the auth provider are stored here. In most cases you can expect a Record<string, string> here.
-  attributes     Json            @default("{}")
+  attributes     Json     @default("{}")
 
   @@unique([email, domainId])
 }

--- a/src/annotations/annotations.ts
+++ b/src/annotations/annotations.ts
@@ -8,31 +8,31 @@ export type Annotation =
   | { type: "OPTIONS"; value: string };
 
 export function isHiddenVariant(
-  annotation: Annotation
+  annotation: Annotation,
 ): annotation is { type: "HIDDEN"; value: number } {
   return annotation.type === "HIDDEN";
 }
 
 export function isHiddenInputVariant(
-  annotation: Annotation
+  annotation: Annotation,
 ): annotation is { type: "HIDDEN_INPUT"; value: number } {
   return annotation.type === "HIDDEN_INPUT";
 }
 
 export function isHiddenInputCreateVariant(
-  annotation: Annotation
+  annotation: Annotation,
 ): annotation is { type: "HIDDEN_INPUT_CREATE"; value: number } {
   return annotation.type === "HIDDEN_INPUT_CREATE";
 }
 
 export function isHiddenInputUpdateVariant(
-  annotation: Annotation
+  annotation: Annotation,
 ): annotation is { type: "HIDDEN_INPUT_UPDATE"; value: number } {
   return annotation.type === "HIDDEN_INPUT_UPDATE";
 }
 
 export function isOptionsVariant(
-  annotation: Annotation
+  annotation: Annotation,
 ): annotation is { type: "OPTIONS"; value: string } {
   return annotation.type === "OPTIONS";
 }
@@ -66,7 +66,7 @@ const annotationKeys: { type: Annotation["type"]; keys: string[] }[] = [
 ];
 
 export function extractAnnotations(
-  input: DMMF.Model["fields"][number]["documentation"]
+  input: DMMF.Model["fields"][number]["documentation"],
 ): {
   annotations: Annotation[];
   description: string | undefined;
@@ -85,19 +85,19 @@ export function extractAnnotations(
     .map((l) => l.trim())
     .filter((l) => l.length > 0)) {
     const annotationKey = annotationKeys.find((key) =>
-      key.keys.some((k) => line.startsWith(k))
+      key.keys.some((k) => line.startsWith(k)),
     );
 
     if (annotationKey) {
       if (annotationKey.type === "OPTIONS") {
         if (!line.startsWith(`${annotationKey.keys[0]}{`)) {
           throw new Error(
-            "Invalid syntax, expected opening { after prismabox.options"
+            "Invalid syntax, expected opening { after prismabox.options",
           );
         }
         if (!line.endsWith("}")) {
           throw new Error(
-            "Invalid syntax, expected closing } for prismabox.options"
+            "Invalid syntax, expected closing } for prismabox.options",
           );
         }
 
@@ -105,7 +105,7 @@ export function extractAnnotations(
           type: "OPTIONS",
           value: line.substring(
             annotationKey.keys[0].length + 1,
-            line.length - 1
+            line.length - 1,
           ),
         });
       } else {

--- a/src/annotations/annotations.ts
+++ b/src/annotations/annotations.ts
@@ -8,31 +8,31 @@ export type Annotation =
   | { type: "OPTIONS"; value: string };
 
 export function isHiddenVariant(
-  annotation: Annotation,
+  annotation: Annotation
 ): annotation is { type: "HIDDEN"; value: number } {
   return annotation.type === "HIDDEN";
 }
 
 export function isHiddenInputVariant(
-  annotation: Annotation,
+  annotation: Annotation
 ): annotation is { type: "HIDDEN_INPUT"; value: number } {
   return annotation.type === "HIDDEN_INPUT";
 }
 
 export function isHiddenInputCreateVariant(
-  annotation: Annotation,
+  annotation: Annotation
 ): annotation is { type: "HIDDEN_INPUT_CREATE"; value: number } {
   return annotation.type === "HIDDEN_INPUT_CREATE";
 }
 
 export function isHiddenInputUpdateVariant(
-  annotation: Annotation,
+  annotation: Annotation
 ): annotation is { type: "HIDDEN_INPUT_UPDATE"; value: number } {
   return annotation.type === "HIDDEN_INPUT_UPDATE";
 }
 
 export function isOptionsVariant(
-  annotation: Annotation,
+  annotation: Annotation
 ): annotation is { type: "OPTIONS"; value: string } {
   return annotation.type === "OPTIONS";
 }
@@ -66,7 +66,7 @@ const annotationKeys: { type: Annotation["type"]; keys: string[] }[] = [
 ];
 
 export function extractAnnotations(
-  input: DMMF.Model["fields"][number]["documentation"],
+  input: DMMF.Model["fields"][number]["documentation"]
 ): {
   annotations: Annotation[];
   description: string | undefined;
@@ -85,19 +85,19 @@ export function extractAnnotations(
     .map((l) => l.trim())
     .filter((l) => l.length > 0)) {
     const annotationKey = annotationKeys.find((key) =>
-      key.keys.some((k) => line.startsWith(k)),
+      key.keys.some((k) => line.startsWith(k))
     );
 
     if (annotationKey) {
       if (annotationKey.type === "OPTIONS") {
         if (!line.startsWith(`${annotationKey.keys[0]}{`)) {
           throw new Error(
-            "Invalid syntax, expected opening { after prismabox.options",
+            "Invalid syntax, expected opening { after prismabox.options"
           );
         }
         if (!line.endsWith("}")) {
           throw new Error(
-            "Invalid syntax, expected closing } for prismabox.options",
+            "Invalid syntax, expected closing } for prismabox.options"
           );
         }
 
@@ -105,7 +105,7 @@ export function extractAnnotations(
           type: "OPTIONS",
           value: line.substring(
             annotationKey.keys[0].length + 1,
-            line.length - 1,
+            line.length - 1
           ),
         });
       } else {
@@ -116,7 +116,7 @@ export function extractAnnotations(
     }
   }
 
-  description = description.trim();
+  description = description.trim().replaceAll("`", "\\`");
   return {
     annotations,
     description: description.length > 0 ? description : undefined,


### PR DESCRIPTION
👋 

Saw this bug when using this package, because I use a lot of Markdown in my comments.

Sorry about the unrelated whitespace changes.