### PR TITLE
Remove `additionalProperties` from options for primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,11 @@ These are called "InputModels" and need to be explicitly enabled in the generato
 4. Hide annotations marked for imports (`@prismabox.input.hide`) are respected.
 
 If enabled, the generator will additonally output more schemes for each model which can be used for creating/updating entities. The model will only allow editing fields of the entity itself. For relations, only connecting/disconnecting is allowed, but changing/creating related entities is not possible.
+
+
+## Notes
+### `__nullable__` vs `Type.Optional`
+
+Prismabox wraps nullable fields in a custom `__nullable__` method which allows `null` in addition to `undefined`. From the relevant [issue comment](https://github.com/m1212e/prismabox/issues/33#issuecomment-2708755442):
+>  prisma in some scenarios allows null OR undefined as types where optional only allows for undefined/is reflected as undefined in TS types
+

--- a/src/generators/plain.ts
+++ b/src/generators/plain.ts
@@ -31,7 +31,7 @@ export function processPlain(models: DMMF.Model[] | Readonly<DMMF.Model[]>) {
 export function stringifyPlain(
   data: DMMF.Model,
   isInputModelCreate = false,
-  isInputModelUpdate = false
+  isInputModelUpdate = false,
 ) {
   const annotations = extractAnnotations(data.documentation);
 
@@ -111,7 +111,7 @@ export function stringifyPlain(
       } else if (processedEnums.find((e) => e.name === field.type)) {
         // biome-ignore lint/style/noNonNullAssertion: we checked this manually
         stringifiedType = processedEnums.find(
-          (e) => e.name === field.type
+          (e) => e.name === field.type,
         )!.stringRepresentation;
       } else {
         return undefined;
@@ -127,7 +127,10 @@ export function stringifyPlain(
         stringifiedType = wrapWithNullable(stringifiedType);
       }
 
-      if (isInputModelUpdate || (isInputModelCreate && !field.isRequired && !field.hasDefaultValue)) {
+      if (
+        isInputModelUpdate ||
+        (isInputModelCreate && !field.isRequired && !field.hasDefaultValue)
+      ) {
         stringifiedType = wrapWithOptional(stringifiedType);
         madeOptional = true;
       }

--- a/src/generators/primitiveField.ts
+++ b/src/generators/primitiveField.ts
@@ -30,7 +30,7 @@ export function stringifyPrimitiveType({
 }) {
   // Remove `additionalProperties` from options for primitives
   const optionsObject = JSON.parse(options);
-  delete optionsObject.additionalProperties;
+  optionsObject.additionalProperties = undefined;
   options = JSON.stringify(optionsObject);
 
   if (["Int", "BigInt"].includes(fieldType)) {

--- a/src/generators/primitiveField.ts
+++ b/src/generators/primitiveField.ts
@@ -28,6 +28,11 @@ export function stringifyPrimitiveType({
   fieldType: PrimitivePrismaFieldType;
   options: string;
 }) {
+  // Remove `additionalProperties` from options for primitives
+  let optionsObject = JSON.parse(options)
+  delete optionsObject.additionalProperties
+  options = JSON.stringify(optionsObject)
+
   if (["Int", "BigInt"].includes(fieldType)) {
     return `${getConfig().typeboxImportVariableName}.Integer(${options})`;
   }

--- a/src/generators/primitiveField.ts
+++ b/src/generators/primitiveField.ts
@@ -29,9 +29,9 @@ export function stringifyPrimitiveType({
   options: string;
 }) {
   // Remove `additionalProperties` from options for primitives
-  let optionsObject = JSON.parse(options)
-  delete optionsObject.additionalProperties
-  options = JSON.stringify(optionsObject)
+  const optionsObject = JSON.parse(options);
+  delete optionsObject.additionalProperties;
+  options = JSON.stringify(optionsObject);
 
   if (["Int", "BigInt"].includes(fieldType)) {
     return `${getConfig().typeboxImportVariableName}.Integer(${options})`;


### PR DESCRIPTION
Closes #33 

Removes `additionalProperties` from options for primitives.

I didn't see a contributor guide, so let me know if there are any tests I should be running or authoring. I'm also not sure how this project handles releases so I didn't bump the package.json.